### PR TITLE
Fix demo import mappings

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <title>Hand Landmarker Demo</title>
   <link rel="stylesheet" href="style.css">
-  <script src="../node_modules/material-components-web/dist/material-components-web.min.js"></script>
-  <script src="../node_modules/@mediapipe/drawing_utils/drawing_utils.js"></script>
-  <script src="../node_modules/@mediapipe/hands/hands.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/material-components-web@14.0.0/dist/material-components-web.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/drawing_utils@0.3.1675466124/drawing_utils.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands.js"></script>
   <style>
     html, body { margin: 0; height: 100%; overflow: hidden; }
     #liveView { position: relative; width: 100%; height: 100%; }
@@ -15,8 +15,8 @@
   <script type="importmap">
     {
       "imports": {
-        "@mediapipe/tasks-vision": "/node_modules/@mediapipe/tasks-vision/vision_bundle.mjs",
-        "@mediapipe/drawing_utils": "/node_modules/@mediapipe/drawing_utils/drawing_utils.js"
+        "@mediapipe/tasks-vision": "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.22-rc.20250304/vision_bundle.mjs",
+        "@mediapipe/drawing_utils": "https://cdn.jsdelivr.net/npm/@mediapipe/drawing_utils@0.3.1675466124/drawing_utils.js"
       }
     }
     </script>

--- a/demo/main.js
+++ b/demo/main.js
@@ -15,7 +15,7 @@
 import {
   HandLandmarker,
   FilesetResolver
-} from "../node_modules/@mediapipe/tasks-vision/vision_bundle.mjs";
+} from "@mediapipe/tasks-vision";
 
 let handLandmarker = undefined;
 let runningMode = "IMAGE";
@@ -26,7 +26,7 @@ let webcamRunning = false;
 // get everything needed to run.
 const createHandLandmarker = async () => {
   const vision = await FilesetResolver.forVisionTasks(
-    "../node_modules/@mediapipe/tasks-vision/wasm"
+    "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.22-rc.20250304/wasm"
   );
   handLandmarker = await HandLandmarker.createFromOptions(vision, {
     baseOptions: {


### PR DESCRIPTION
## Summary
- use CDN URLs for Material Components and MediaPipe libs in demo
- update MediaPipe import map accordingly
- reference import map in demo JS file

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e6ccd06b48328aab8bd1d82c829fe